### PR TITLE
Add CramMD5 auth 

### DIFF
--- a/EMailSender.h
+++ b/EMailSender.h
@@ -462,6 +462,13 @@ public:
 		this->isSASLLogin = isSASLLogin;
 	}
 
+#if defined(ESP32)
+	// Conditional - as it relies on considerable crypto infra.
+ 	void setCramMD5Login(bool onoff= false) {
+ 		this->isCramMD5Login = onoff;
+ 	}
+#endif
+
 	void setAdditionalResponseLineOnConnection(uint8_t numLines = 0) {
 		this->additionalResponseLineOnConnection = numLines;
 	}
@@ -485,6 +492,7 @@ private:
 	bool isSASLLogin = false;
 
 	bool useAuth = true;
+        bool isCramMD5Login = false;
 
     String _serverResponce;
 


### PR DESCRIPTION
Add CramMD5 auth  for platforms that have enough crypto to support this (currently that is, I think, just the ESP32). 

This is increasingly needed/easy if you want to post through various MTA-as-a-Service parties.
