### PR TITLE
Add a newline before the first boundary.

### DIFF
--- a/EMailSender.cpp
+++ b/EMailSender.cpp
@@ -803,6 +803,7 @@ EMailSender::Response EMailSender::send(const char* to[], byte sizeOfTo,  byte s
   client.println(F("MIME-Version: 1.0"));
   client.println(F("Content-Type: Multipart/mixed; boundary=frontier"));
 
+  client.println();
   client.println(F("--frontier"));
 
     client.print(F("Content-Type: "));


### PR DESCRIPTION
This is required for less flexible SMTPs (like Amazon SES), as explained in section 7.2.1 [of the RFC](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html).

Without it, e-mail sending can fail with `554 Transaction failed: Duplicate header 'Content-Type'`.

Tested with the `Esp8266GMailTestSetName` example using Amazon SES and GMail accounts.

Fixes issue #49.